### PR TITLE
Use %f instead of %g in LatLng.String()

### DIFF
--- a/latlng.go
+++ b/latlng.go
@@ -57,7 +57,7 @@ func ParseLatLngList(locations string) ([]LatLng, error) {
 }
 
 func (l *LatLng) String() string {
-	return fmt.Sprintf("%g,%g", l.Lat, l.Lng)
+	return fmt.Sprintf("%f,%f", l.Lat, l.Lng)
 }
 
 // AlmostEqual returns whether this LatLng is almost equal (below epsilon) to


### PR DESCRIPTION
fmt.Sprintf with %g will encode floats using the scientific notation (%e) instead of decimal point notation (%f) if the exponent is large enough. In practice, latitudes/longitudes <=0.0001 will be converted with %e, while the Google Maps APIs don't support this notation. This can be prevented by always converting those LatLng to string with %f.

The default decimal precision of %f is 6 (https://golang.org/pkg/fmt/). This should be enough for API queries (about 111.32 mm at equator, https://en.wikipedia.org/wiki/Decimal_degrees).